### PR TITLE
CCPVersioner

### DIFF
--- a/Adobe/CFBundleVersionExtensionAttribute.xml
+++ b/Adobe/CFBundleVersionExtensionAttribute.xml
@@ -1,0 +1,19 @@
+<computer_extension_attribute>
+	<name>%NAME%Version</name>
+	<description />
+	<data_type>String</data_type>
+	<input_type>
+		<type>script</type>
+		<platform>Mac</platform>
+		<script>#!/bin/assh
+CFBundleVersion=""
+if [ -f "/Applications/%NAME%.app/Contents/Info.plist" ]; then
+    CFBundleVersion=$(defaults read "/Applications/%NAME%.app/Contents/Info.plist" CFBundleVersion)
+fi
+echo "&lt;result&gt;$CFBundleVersion&lt;/result&gt;"
+exit 0
+        </script>
+	</input_type>
+	<inventory_display>Extension Attributes</inventory_display>
+	<recon_display>Extension Attributes</recon_display>
+</computer_extension_attribute>

--- a/Adobe/CFBundleVersionSmartGroupTemplate.xml
+++ b/Adobe/CFBundleVersionSmartGroupTemplate.xml
@@ -1,0 +1,34 @@
+<computer_group>
+	<name>%group_name%</name>
+	<is_smart>true</is_smart>
+	<criteria>
+		<criterion>
+			<name>Application Title</name>
+			<priority>0</priority>
+			<and_or>and</and_or>
+			<search_type>is</search_type>
+			<value>%JSS_INVENTORY_NAME%</value>
+		</criterion>
+		<criterion>
+			<name>%NAME%Version</name>
+			<priority>1</priority>
+			<and_or>and</and_or>
+			<search_type>is not</search_type>
+			<value>%VERSION%</value>
+		</criterion>
+		<criterion>
+			<name>%NAME%Version</name>
+			<priority>2</priority>
+			<and_or>and</and_or>
+			<search_type>is not</search_type>
+			<value></value>
+		</criterion>
+		<criterion>
+			<name>Computer Group</name>
+			<priority>3</priority>
+			<and_or>and</and_or>
+			<search_type>member of</search_type>
+			<value>Testing</value>
+		</criterion>
+	</criteria>
+</computer_group>

--- a/Adobe/CreativeCloudApp.munki.recipe
+++ b/Adobe/CreativeCloudApp.munki.recipe
@@ -60,18 +60,6 @@
                 </dict>
             </dict>
             <dict>
-                <key>Arguments</key>
-                <dict>
-                    <key>additional_pkginfo</key>
-                    <dict>
-                        <key>version</key>
-                        <string>%version%</string>
-                        <key>minimum_os_version</key>
-                        <string>%minimum_os_version%</string>
-                        <key>display_name</key>
-                        <string>%display_name%</string>
-                    </dict>
-                </dict>
                 <key>Processor</key>
                 <string>MunkiPkginfoMerger</string>
             </dict>

--- a/Adobe/CreativeCloudApp.pkg.recipe
+++ b/Adobe/CreativeCloudApp.pkg.recipe
@@ -97,6 +97,10 @@ Other Input values here correspond to options provided in the CCP UI.</string>
                     <string>%NAME%</string>
                 </dict>
             </dict>
+            <dict>
+                <key>Processor</key>
+                <string>CreativeCloudVersioner</string>
+            </dict>
         </array>
     </dict>
 </plist>

--- a/Adobe/CreativeCloudVersioner.py
+++ b/Adobe/CreativeCloudVersioner.py
@@ -209,6 +209,7 @@ class CreativeCloudVersioner(Processor):
         ''' Create pkginfo will found details '''
         pkginfo = {}
         self.env["version"] = app_version
+        self.env["prod_name"] = self.env["display_name"]
         pkginfo["version"] = self.env["version"]
         pkginfo["display_name"] = self.env["display_name"]
         pkginfo["minimum_os_version"] = self.env["minimum_os_version"]

--- a/Adobe/CreativeCloudVersioner.py
+++ b/Adobe/CreativeCloudVersioner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright 2016 Mosen/Tim Sutton
+# Copyright 2017 Mosen/Tim Sutton/Macmule
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Adobe/CreativeCloudVersioner.py
+++ b/Adobe/CreativeCloudVersioner.py
@@ -63,6 +63,12 @@ class CreativeCloudVersioner(Processor):
             "description":
                 "Some pkginfo fields extracted from the Adobe metadata.",
         },
+        "display_name": {
+            "description": "The product full name and major version"
+        },
+        "package_info_text": {
+            "description": "Text notes about which packages and updates are included in the pkg."
+        },
         "pkg_path": {
             "description": "Path to the built bundle-style CCP installer pkg.",
         },

--- a/Adobe/CreativeCloudVersioner.py
+++ b/Adobe/CreativeCloudVersioner.py
@@ -63,9 +63,6 @@ class CreativeCloudVersioner(Processor):
             "description":
                 "Some pkginfo fields extracted from the Adobe metadata.",
         },
-        "display_name": {
-            "description": "The product full name and major version"
-        },
         "package_info_text": {
             "description": "Text notes about which packages and updates are included in the pkg."
         },

--- a/Adobe/CreativeCloudVersioner.py
+++ b/Adobe/CreativeCloudVersioner.py
@@ -1,0 +1,224 @@
+#!/usr/bin/python
+
+# Copyright 2016 Mosen/Tim Sutton
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=locally-disabled, import-error, invalid-name, no-member
+
+# for now
+# pylint: disable=line-too-long
+
+import json
+import os
+import re
+import zipfile
+
+from xml.etree import ElementTree
+
+import FoundationPlist
+from autopkglib import Processor, ProcessorError
+
+__all__ = ["CreativeCloudVersioner"]
+
+
+class CreativeCloudVersioner(Processor):
+    '''Generates installs from CCP created installers '''
+    description = "Runs the CCP packager."
+    input_variables = {
+        "ccpinfo": {
+            "required": True,
+            "description": "Creative Cloud Packager Product(s) Information",
+        },
+        "pkg_path": {
+            "required": True,
+            "description": "Path to the built bundle-style CCP installer pkg.",
+        },
+        "uninstaller_pkg_path": {
+            "required": True,
+            "description": "Path to the built bundle-style CCP uninstaller pkg.",
+        },
+        "display_name": {
+            "required": True,
+            "description": "The product full name and major version"
+        },
+        "minimum_os_version": {
+            "required": True,
+            "description": "The minimum operating system version required to install this package"
+        },
+    }
+
+    output_variables = {
+        "additional_pkginfo": {
+            "description":
+                "Some pkginfo fields extracted from the Adobe metadata.",
+        },
+        "pkg_path": {
+            "description": "Path to the built bundle-style CCP installer pkg.",
+        },
+        "uninstaller_pkg_path": {
+            "description": "Path to the built bundle-style CCP uninstaller pkg.",
+        },
+    }
+
+
+    def main(self):
+        ''' Read .json & .pimx to .app, then read info.plist'''
+        ccpinfo = self.env["ccpinfo"]
+        self.env["prod"] = ccpinfo["Products"]
+        self.env["sapCode"] = self.env["prod"][0]["sapCode"]
+        self.output("sapCode: %s" % self.env["sapCode"])
+        self.env["ccpVersion"] = self.env["prod"][0]["version"]
+        self.output("ccpVersion: %s" % self.env["ccpVersion"])
+        self.env["app_json"] = os.path.join(self.env["pkg_path"], "Contents/Resources/HD", self.env["sapCode"] + self.env["ccpVersion"], "Application.json")
+        # If Application.json exists, we"re looking at a HD installer
+        if os.path.exists(self.env["app_json"]):
+            self.output("app_json: %s" % self.env["app_json"])
+            self.process_hd_installer()
+        else:
+            # If not a HD installer
+            # Legacy Installers: PKG"s but for old titles
+            # RIBS: SPGD, LTRM, FLBR, KETK
+            # If the above get moved to HD installs, won"t hit this.
+            # Acrobat is a "current" title with a PKG installer we can extract needed
+            # metadata from
+            if self.env["sapCode"] != "APRO":
+                raise ProcessorError("RIBS or legacy installer detected")
+            else:
+                self.env["proxy_xml"] = os.path.join(self.env["pkg_path"], "Contents/Resources/Setup", self.env["sapCode"] + self.env["ccpVersion"], "proxy.xml")
+                if not os.path.exists(self.env["proxy_xml"]):
+                    raise ProcessorError("APRO selected, proxy.xml not found at %s" % self.env["proxy_xml"])
+                else:
+                    self.process_apro_installer()
+
+
+    def process_apro_installer(self):
+        ''' Process APRO installer '''
+        self.output("Processing Acrobat installer")
+        self.output("proxy_xml: %s" % self.env["proxy_xml"])
+        tree = ElementTree.parse(self.env["proxy_xml"])
+        # The below parses the proxy.xml for the info needs to build an installs.
+        # Tried to be verbose in selecting elements, in the hope we don"t trip up
+        for elem in list(tree.iter("Properties")):
+            for sub_elem in elem.getchildren():
+                if sub_elem.attrib["name"].startswith("path"):
+                    app_bundle = re.split("/", sub_elem.text)[1]
+                    self.output("app_bundle: %s" % app_bundle)
+
+        for elem in list(tree.iter("InstallDir")):
+            for sub_elem in elem.getchildren():
+                if sub_elem.text.startswith("[AdobeProgramFiles]"):
+                    app_path = re.split("/", sub_elem.text)[1]
+                    self.output("app_path: %s" % app_path)
+
+        installed_path = os.path.join("/Applications", app_path, app_bundle)
+        self.output("installed_path: %s" % installed_path)
+
+        for elem in list(tree.iter("InstallerProperties")):
+            for sub_elem in elem.getchildren():
+                if sub_elem.attrib["name"].startswith("ProductVersion"):
+                    app_version = sub_elem.text
+                    self.output("app_version: %s" % app_version)
+
+        #for elem in list(tree.iter("Application")):
+        #    app_identifier = elem.attrib["CFBundleIdentifier"]
+        #    self.output("app_identifier: %s" % app_identifier)
+
+        # Now we have the deets, let"s use them
+        self.create_pkginfo(app_version, installed_path)
+
+
+    def process_hd_installer(self):
+        ''' Process HD installer '''
+        self.output("Processing HD installer")
+        with open(self.env["app_json"]) as json_file:
+            load_json = json.load(json_file)
+            # AppLaunch is not always in the same format, but is splittable
+            app_launch = load_json["AppLaunch"]
+            self.output("app_launch: %s" % app_launch)
+            app_details = list(re.split("/", app_launch))
+            if app_details[2].endswith(".app"):
+                app_bundle = app_details[2]
+                app_path = app_details[1]
+            else:
+                app_bundle = app_details[1]
+                app_path = list(re.split("/", (load_json["InstallDir"]["value"])))[1]
+            self.output("app_bundle: %s" % app_bundle)
+            self.output("app_path: %s" % app_path)
+
+            installed_path = os.path.join("/Applications", app_path, app_bundle)
+            self.output("installed_path: %s" % installed_path)
+            zip_file = load_json["Packages"]["Package"][0]["PackageName"]
+            self.output("zip_file: %s" % zip_file)
+
+            zip_path = os.path.join(self.env["pkg_path"], "Contents/Resources/HD", self.env["sapCode"] + self.env["ccpVersion"], zip_file + ".zip")
+            self.output("zip_path: %s" % zip_path)
+            with zipfile.ZipFile(zip_path, mode="r") as myzip:
+                with myzip.open(zip_file + ".pimx") as mytxt:
+                    txt = mytxt.read()
+                    tree = ElementTree.fromstring(txt)
+                    # Loop through .pmx"s Assets, look for target=[INSTALLDIR], then grab Assets Source.
+                    # Break when found .app/Contents/Info.plist
+                    for elem in tree.findall("Assets"):
+                        for i in  elem.getchildren():
+                            if i.attrib["target"].upper().startswith("[INSTALLDIR]"):
+                                bundle_location = i.attrib["source"]
+                            else:
+                                continue
+                            if not bundle_location.startswith("[StagingFolder]"):
+                                continue
+                            else:
+                                bundle_location = bundle_location[16:]
+                                if bundle_location.endswith(".app"):
+                                    zip_bundle = os.path.join("1", bundle_location, "Contents/Info.plist")
+                                else:
+                                    zip_bundle = os.path.join("1", bundle_location, app_bundle, "Contents/Info.plist")
+                                try:
+                                    with myzip.open(zip_bundle) as myplist:
+                                        plist = myplist.read()
+                                        data = FoundationPlist.readPlistFromString(plist)
+                                        app_version = data["CFBundleShortVersionString"]
+                                        #app_identifier = data["CFBundleIdentifier"]
+                                        self.output("staging_folder: %s" % bundle_location)
+                                        self.output("staging_folder_path: %s" % zip_bundle)
+                                        self.output("app_version: %s" % app_version)
+                                        self.output("app_bundle: %s" % app_bundle)
+                                        #self.output("app_identifier: %s" % app_identifier)
+                                        break
+                                except:
+                                    continue
+
+        # Now we have the deets, let"s use them
+        self.create_pkginfo(app_version, installed_path)
+
+
+    def create_pkginfo(self, app_version, installed_path):
+        ''' Create pkginfo will found details '''
+        pkginfo = {}
+        self.env["version"] = app_version
+        pkginfo["version"] = self.env["version"]
+        pkginfo["display_name"] = self.env["display_name"]
+        pkginfo["minimum_os_version"] = self.env["minimum_os_version"]
+        pkginfo["installs"] = [{
+            #"CFBundleIdentifier": app_identifier,
+            "CFBundleShortVersionString": self.env["version"],
+            "path": installed_path,
+            "type": "bundle",
+            "version_comparison_key": "CFBundleShortVersionString",
+        }]
+        self.env["additional_pkginfo"] = pkginfo
+        self.output("additional_pkginfo: %s" % self.env["additional_pkginfo"])
+
+
+if __name__ == "__main__":
+    processor = CreativeCloudVersioner()

--- a/Adobe/PolicyTemplate.xml
+++ b/Adobe/PolicyTemplate.xml
@@ -1,0 +1,27 @@
+<policy>
+	<general>
+		<name>Install Latest %PROD_NAME%</name>
+		<enabled>true</enabled>
+		<frequency>Ongoing</frequency>
+		<category>
+			<name>%POLICY_CATEGORY%</name>
+		</category>
+	</general>
+	<scope>
+		<!--Scope added by JSSImporter-->
+	</scope>
+	<package_configuration>
+		<!--Package added by JSSImporter-->
+	</package_configuration>
+	<scripts>
+		<!--Scripts added by JSSImporter-->
+	</scripts>
+	<self_service>
+		<use_for_self_service>true</use_for_self_service>
+		<install_button_text>Install %VERSION%</install_button_text>
+		<self_service_description>%SELF_SERVICE_DESCRIPTION%</self_service_description>
+	</self_service>
+	<maintenance>
+		<recon>true</recon>
+	</maintenance>
+</policy>

--- a/Adobe/ScriptTemplate.xml
+++ b/Adobe/ScriptTemplate.xml
@@ -1,0 +1,10 @@
+<script>
+	<name>TestScript.sh</name>
+	<category>Testing</category>
+	<filename>TestScript.sh</filename>
+	<info />
+	<notes />
+	<priority>After</priority>
+	<parameters />
+	<os_requirements />
+</script>

--- a/Adobe/SmartGroupTemplate.xml
+++ b/Adobe/SmartGroupTemplate.xml
@@ -1,0 +1,27 @@
+<computer_group>
+	<name>%group_name%</name>
+	<is_smart>true</is_smart>
+	<criteria>
+		<criterion>
+			<name>Application Title</name>
+			<priority>0</priority>
+			<and_or>and</and_or>
+			<search_type>is</search_type>
+			<value>%JSS_INVENTORY_NAME%</value>
+		</criterion>
+		<criterion>
+			<name>Application Version</name>
+			<priority>1</priority>
+			<and_or>and</and_or>
+			<search_type>is not</search_type>
+			<value>%VERSION%</value>
+		</criterion>
+		<criterion>
+			<name>Computer Group</name>
+			<priority>2</priority>
+			<and_or>and</and_or>
+			<search_type>member of</search_type>
+			<value>Testing</value>
+		</criterion>
+	</criteria>
+</computer_group>


### PR DESCRIPTION
Added CCPVersioner Processor to generate installs array from downloaded media for HD & APRO installers.

TODO: Munki recipes seem fine, but JSS recipes are not complete & have some issues.

The needed .xml have been added, but there is some ways to go to pass correct information to JSS.

Issues such as:
1) Variable for name
2) Keep app bundle as-is when creating smart group criteria
3) Append version number to PKG for jss.recipes

The CFBundleShortVersionString is being imported into munki & jss correctly.

Also, Munki installs attar is using the “new” bundle path format.